### PR TITLE
Add Galician (gl-ES) locale support

### DIFF
--- a/src/commons/base.js
+++ b/src/commons/base.js
@@ -1,7 +1,7 @@
 import { select, pointer } from "d3-selection";
 import { timeFormatDefaultLocale } from "d3-time-format";
 import { version } from "../../package.json"
-import { es, ca } from "./locales"
+import { es, ca, gl } from "./locales"
 
 import "./palette.css"
 import "./tooltip.css"
@@ -9,6 +9,7 @@ import "./tooltip.css"
 const DEFAULT_LOCALES = {
   "es-ES": es,
   "ca-ES": ca,
+  "gl-ES": gl,
 }
 
 export default class Base {

--- a/src/commons/locales.js
+++ b/src/commons/locales.js
@@ -19,3 +19,14 @@ export const ca = {
   "months": ["gener", "febrer", "març", "abril", "maig", "juny", "juliol", "agost", "setembre", "octubre", "novembre", "desembre"],
   "shortMonths": ["gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des."]
 }
+
+export const gl = {
+  "dateTime": "%A, %e de %B de %Y, %X",
+  "date": "%d/%m/%Y",
+  "time": "%H:%M:%S",
+  "periods": ["AM", "PM"],
+  "days": ["domingo", "luns", "martes", "mércores", "xoves", "venres", "sábado"],
+  "shortDays": ["dom", "lun", "mar", "mér", "xov", "ven", "sáb"],
+  "months": ["xaneiro", "febreiro", "marzo", "abril", "maio", "xuño", "xullo", "agosto", "setembro", "outubro", "novembro", "decembro"],
+  "shortMonths": ["xan", "feb", "mar", "abr", "mai", "xuñ", "xul", "ago", "set", "out", "nov", "dec"]
+}


### PR DESCRIPTION
## Summary
Adds Galician language support to the d3 time format locales. The locale code is `gl-ES` and includes translations for day names, month names, and date/time format strings.

## Changes
- Add `gl` export to `src/commons/locales.js` with Galician translations
- Import `gl` in `src/commons/base.js` and register it in `DEFAULT_LOCALES`

Users can now use the `gl-ES` locale when instantiating chart classes.